### PR TITLE
add https service URL

### DIFF
--- a/lv/examples/routing_simple.html
+++ b/lv/examples/routing_simple.html
@@ -23,6 +23,9 @@
             }).addTo(map);
 
             var routing = L.Routing.control({
+                router: new L.Routing.OSRMv1({
+                  serviceUrl: 'https://router.project-osrm.org/route/v1',
+                }),
                 fitSelectedRoutes : true
             }).addTo(map);
 


### PR DESCRIPTION
workaround to prevent loading mixed content. serviceUrl is hard coded in leaflet-routing-machine to http, [see here](https://github.com/perliedman/leaflet-routing-machine/commit/bd0407ad891c5d2b2329de35ee285ef4008f769a#diff-a6014ce1029e76c2ef6ff7c1927b01a8L2021).